### PR TITLE
Allow multiple arguments that gets formatted in log(), fixes #1.

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,24 @@
 'use strict';
 var Logger = require('./lib/logger');
 
-exports.register = function (server, options, next) {
+var internals = {
+	instances: {}
+};
+
+module.exports = function (name, opts) {
+	if (typeof(name) === 'object') {
+		opts = name;
+		name = '_default';
+	}
+
+	if (!internals.instances[name]) {
+		internals.instances[name] = new Logger(opts);
+	}
+
+	return internals.instances[name];
+};
+
+module.exports.register = function (server, options, next) {
 	var log = new Logger(options);
 	server.on('request', log.handleRequest.bind(log));
 	server.on('response', log.handleResponse.bind(log));
@@ -21,11 +38,12 @@ exports.register = function (server, options, next) {
 		});
 	}
 
+	internals.instances[options.name || 'hapi'] = log;
 	next();
 };
 
-exports.register.attributes = {
+module.exports.register.attributes = {
 	name: 'service-log'
 };
 
-exports.Logger = Logger;
+module.exports.Logger = Logger;

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,6 +4,7 @@ var Hoek = require('hoek');
 var moment = require('moment');
 var printf = require('util').format;
 var stringify = require('json-stringify-safe');
+var inspect = require('util').inspect;
 
 var internals = {
 	defaults: {
@@ -146,13 +147,24 @@ Logger.prototype.write = function (obj) {
 /**
  * Add a log entry
  * @param  {Array|String} tags
- * @param  {Object|String} msg
+ * @param  {Object|String} msg...
  */
 Logger.prototype.log = function (tags, msg) {
+	var messages = Array.prototype.slice.call(arguments, 1).map(function (arg) {
+		if (arg instanceof Error) {
+			return arg.stack;
+		}
+
+		if (arg instanceof Object) {
+			return inspect(arg);
+		}
+		return arg;
+	});
+
 	var payload = {
 		timestamp: Date.now(),
 		tags: Array.isArray(tags) ? tags : [tags],
-		log: msg
+		log: printf.apply(printf, messages)
 	};
 
 	var meta = this.meta();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,8 +1,8 @@
 'use strict';
 var Hapi = require('hapi');
 var sinon = require('sinon');
-
-require('should');
+var should = require('should');
+var plugin = require('../');
 
 describe('Log service', function () {
 	var server;
@@ -17,7 +17,7 @@ describe('Log service', function () {
 		server = new Hapi.Server({debug: false});
 		server.connection();
 		server.register({
-				register: require('../'),
+				register: plugin,
 				options: {handler: testHandler}
 			},
 			function (err) {
@@ -81,6 +81,17 @@ describe('Log service', function () {
 	it('should handle log event', function () {
 		server.log('foo', 'bar');
 		consoleSpy.firstCall.args[0].should.endWith('[log,foo], bar');
+	});
+
+	it('should set default name for instance', function () {
+		var log1 = plugin();
+		should.ok(plugin() === log1);
+	});
+
+	it('should set name for instance', function () {
+		var log1 = plugin('foo');
+		should.ok(plugin() !== log1);
+		should.ok(plugin('foo') === log1);
 	});
 
 	function route(path, handler) {

--- a/test/lib/logger.test.js
+++ b/test/lib/logger.test.js
@@ -36,4 +36,16 @@ describe('Logger', function () {
 		consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo');
 	});
 
+	it('should allow multiple messages', function () {
+		log = new Logger({handler: testHandler});
+		log.log(['info', 'debug'], 'foo', {foo: 'bar'}, 'ping');
+		consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo { foo: \'bar\' } ping');
+	});
+
+	it('should interpolate messages', function () {
+		log = new Logger({handler: testHandler});
+		log.log(['info', 'debug'], '%s,%s', 'foo', 'bar');
+		consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo,bar');
+	});
+
 });


### PR DESCRIPTION
Add convenience method for getting a singleton instance of Logger, fixes #2.
