### PR TITLE
Add json output format. (enabled by default)

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var internals = {
 };
 
 module.exports = function (name, opts) {
+	name = name || '_default';
 	if (typeof(name) === 'object') {
 		opts = name;
 		name = '_default';

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -8,6 +8,7 @@ var inspect = require('util').inspect;
 
 var internals = {
 	defaults: {
+		jsonOutput: true,
 		format: 'YYYY-MM-DD HH:mm:ss.SSS',
 		utc: false
 	}
@@ -22,18 +23,41 @@ function defaultMeta(request) {
 	if (!request) {
 		return;
 	}
-	return {id: request.id};
+	return {requestId: request.id};
 }
+
+/**
+ * @typedef {Object} RequestInfo
+ * @property {String} remoteAddress
+ * @property {String} host
+ * @property {String} path
+ * @property {String} method
+ * @property {Object} query
+ * @property {Number} statusCode
+ * @property {Number} responseTime
+ * @property {String} userAgent
+ * @property {String} [referer]
+ */
+
+/**
+ * @typedef {Object} LogData
+ * @property {Integer} timestamp when the log event occured
+ * @property {String[]} tags
+ * @property {Object|String} [log] the log message or object
+ * @property {RequestInfo} [requestInfo]
+ * @property {Object} [data] optional meta data
+ */
 
 /**
  * Creates a new Logger
  *
  * @class Logger
- * @param {Object} options
- * @param {String} options.format date format string
- * @param {Boolean} options.utc UTC date
+ * @param {Object} [options]
+ * @param {String} [options.format] date format string
+ * @param {Boolean} [options.utc] UTC date
+ * @param {Boolean} [options.jsonOutput] output all data as stringified json
  * @param {Object} [options.handler] Handler implementing `log(message)` method, defaults to console logging
- * @param {Function} [options.meta] Should return meta data as an Object that is appended to logs. Default returns {id:request.id} This function doesnt always recieve request object.
+ * @param {Function} [options.meta] Should return meta data as an Object that is appended to logs. Default returns {requestId:request.id} This function doesnt always recieve request object.
  */
 var Logger = module.exports = function Logger(options) {
 	this.opts = Hoek.applyToDefaults(internals.defaults, options || {});
@@ -90,26 +114,47 @@ Logger.prototype.handleRequest = function (request, event) {
 Logger.prototype.handleResponse = function (request) {
 	var referer = request.raw.req.headers.referer;
 
-	var log = printf(
-		'%s, %s %s %s %s %s (%sms), %s%s',
-		request.info.remoteAddress,
-		request.connection.info.uri,
-		request.path,
-		request.method,
-		JSON.stringify(request.query),
-		request.raw.res.statusCode,
-		Date.now() - request.info.received,
-		referer ? referer + ', ' : '',
-		request.raw.req.headers['user-agent']
-	);
+	var requestInfo = {
+		remoteAddress: request.info.remoteAddress,
+		host: request.connection.info.uri,
+		path: request.path,
+		method: request.method,
+		query: request.query,
+		statusCode: request.raw.res.statusCode,
+		responseTime: Date.now() - request.info.received,
+		userAgent: request.raw.req.headers['user-agent']
+	};
+
+	if (referer) {
+		requestInfo.referer = referer;
+	}
 
 	this.write({
 		timestamp: request.info.received,
 		tags: ['response'],
 		data: this.meta(request),
-		log: log
+		requestInfo: requestInfo
 	});
+};
 
+/**
+ * Format RequestInfo to a human friendly string
+ * @param  {RequestInfo} data
+ * @return {String}
+ */
+Logger.prototype.stringifyRequestInfo = function (data) {
+	return printf(
+		'%s, %s %s %s %s %s (%sms), %s%s',
+		data.remoteAddress,
+		data.host,
+		data.path,
+		data.method,
+		stringify(data.query),
+		data.statusCode,
+		data.responseTime,
+		data.referer ? data.referer + ', ' : '',
+		data.userAgent
+	);
 };
 
 /**
@@ -125,23 +170,65 @@ Logger.prototype.handleLog = function (event) {
 };
 
 /**
- * Write formatted object with logging details
- * @param  {Object} obj
- * @param  {Integer} obj.timestamp
- * @param  {Array} obj.tags
- * @param  {Object|String} obj.log the log message or data
- * @param {Object} [obj.data] optional meta data
+ * Format log data to human readable string
+ * @param  {LogData} obj
+ * @return {String}
  */
-Logger.prototype.write = function (obj) {
-	var formatted = printf(
+Logger.prototype.humanReadableFormatter = function (obj) {
+	var log;
+	if (obj.requestInfo) {
+		// requestInfo is only sent on response log
+		log = this.stringifyRequestInfo(obj.requestInfo);
+	} else {
+		log = typeof obj.log === 'object' ? inspect(obj.log) : obj.log;
+	}
+
+	return printf(
 		'%s, [%s], %s%s',
 		this.formatTime(obj.timestamp),
 		obj.tags,
-		typeof(obj.log) === 'object' ? stringify(obj.log) : obj.log,
+		log,
 		obj.data ? ', ' + stringify(obj.data) : ''
 	);
+};
 
-	this.handler.log(formatted);
+/**
+ * Formats Log to a string
+ * @param  {LogData} obj
+ * @return {String}
+ */
+Logger.prototype.formatter = function (obj) {
+	if (!this.opts.jsonOutput) {
+		return this.humanReadableFormatter(obj);
+	}
+
+	var formatted = {
+		time: this.formatTime(obj.timestamp),
+		tags: obj.tags
+	};
+
+	formatted = Hoek.applyToDefaults(formatted, obj.data || {});
+	formatted = Hoek.applyToDefaults(formatted, obj.requestInfo || {});
+
+	if (obj.log && typeof obj.log === 'object') {
+		if (obj.log instanceof Error) {
+			formatted.error = obj.log.stack;
+		} else {
+			formatted = Hoek.applyToDefaults(formatted, obj.log);
+		}
+	} else {
+		formatted.msg = obj.log;
+	}
+
+	return stringify(formatted);
+};
+
+/**
+ * Formats and writes the log data
+ * @param  {LogData} obj
+ */
+Logger.prototype.write = function (obj) {
+	this.handler.log(this.formatter(obj));
 };
 
 /**
@@ -150,21 +237,35 @@ Logger.prototype.write = function (obj) {
  * @param  {Object|String} msg...
  */
 Logger.prototype.log = function (tags, msg) {
-	var messages = Array.prototype.slice.call(arguments, 1).map(function (arg) {
-		if (arg instanceof Error) {
-			return arg.stack;
+	var messages = Array.prototype.slice.call(arguments, 1);
+
+	// only apply printf if it has multiple messages
+	// we want to be able to handle a single error objects for jsonOutput differently
+	if (messages.length > 1) {
+		messages = messages.map(function (arg) {
+			if (arg instanceof Error) {
+				return arg.stack;
+			}
+
+			if (arg instanceof Object) {
+				return inspect(arg);
+			}
+			return arg;
+		});
+
+		messages = printf.apply(printf, messages);
+	} else {
+		if (!this.opts.jsonOutput && messages[0] instanceof Object) {
+			messages[0] = inspect(messages[0]);
 		}
 
-		if (arg instanceof Object) {
-			return inspect(arg);
-		}
-		return arg;
-	});
+		messages = messages[0];
+	}
 
 	var payload = {
 		timestamp: Date.now(),
 		tags: Array.isArray(tags) ? tags : [tags],
-		log: printf.apply(printf, messages)
+		log: messages
 	};
 
 	var meta = this.meta();

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "url": "git@github.com:aptoma/hapi-log.git"
   },
   "scripts": {
-    "test": "NODE_ENV=test jscs test/ lib/ *.js && jshint test/ lib/ *.js && istanbul cover -i '*.js lib/*.js' _mocha -- -u exports -R spec 'test/**/*.test.js'",
+    "test": "NODE_ENV=test jscs test/ lib/ *.js && jshint test/ lib/ *.js && istanbul cover -i '*.js lib/*.js' _mocha -- -u exports -R spec 'test/**/*.test.js' && npm run coverage",
     "watch": "mocha --watch 'test/**/*.js' --timeout 500",
+    "coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
     "ci": "NODE_ENV=test npm test --coverage && istanbul report cobertura && nsp shrinkwrap",
     "release": "npm test && release-it -n -i patch",
     "release:minor": "npm test && release-it -n -i minor",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "NODE_ENV=test jscs test/ lib/ *.js && jshint test/ lib/ *.js && istanbul cover -i '*.js lib/*.js' _mocha -- -u exports -R spec 'test/**/*.test.js' && npm run coverage",
     "watch": "mocha --watch 'test/**/*.js' --timeout 500",
     "coverage": "istanbul check-coverage --statement 100 --branch 100 --function 100",
-    "ci": "NODE_ENV=test npm test --coverage && istanbul report cobertura && nsp shrinkwrap",
+    "ci": "NODE_ENV=test npm test --coverage && istanbul report cobertura && nsp check",
     "release": "npm test && release-it -n -i patch",
     "release:minor": "npm test && release-it -n -i minor",
     "release:major": "npm test && release-it -n -i major"
@@ -29,7 +29,7 @@
     "jscs": "^1.11.3",
     "jshint": "^2.6.3",
     "mocha": "^2.2.1",
-    "nsp": "^1.1.0",
+    "nsp": "^2.0.2",
     "release-it": "^2.0.3",
     "should": "^7.0.1",
     "sinon": "^1.16.1"

--- a/test/lib/logger.test.js
+++ b/test/lib/logger.test.js
@@ -1,6 +1,8 @@
 'use strict';
 var sinon = require('sinon');
+var moment = require('moment');
 var Logger = require('../../lib/logger');
+var should = require('should');
 
 describe('Logger', function () {
 	var consoleSpy;
@@ -18,34 +20,83 @@ describe('Logger', function () {
 		testHandler.log.restore();
 	});
 
-	it('should use custom meta function', function () {
+	it('should support custom timeformat', function () {
 		log = new Logger({
+			jsonOutput: true,
 			handler: testHandler,
-			meta: function () {
-				return {foo: 'bar'};
-			}
+			format: 'YYYY-MM-DD HH:mm:ss',
+			utc: true
 		});
 
 		log.log('info', 'foo');
-		consoleSpy.firstCall.args[0].should.endWith('[info], foo, {"foo":"bar"}');
+		var json = JSON.parse(consoleSpy.firstCall.args[0]);
+		json.time.should.equal(moment().format('YYYY-MM-DD HH:mm:ss'));
 	});
 
-	it('should log message with multiple tags', function () {
-		log = new Logger({handler: testHandler});
-		log.log(['info', 'debug'], 'foo');
-		consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo');
+	describe('humanReadable Format', function () {
+
+		it('should use custom meta function', function () {
+			log = new Logger({
+				jsonOutput: false,
+				handler: testHandler,
+				meta: function () {
+					return {foo: 'bar'};
+				}
+			});
+
+			log.log('info', 'foo');
+			consoleSpy.firstCall.args[0].should.endWith('[info], foo, {"foo":"bar"}');
+		});
+
+		it('should log message with multiple tags', function () {
+			log = new Logger({handler: testHandler, jsonOutput: false});
+			log.log(['info', 'debug'], 'foo');
+			consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo');
+		});
+
+		it('should log object', function () {
+			log = new Logger({handler: testHandler, jsonOutput: false});
+			log.log(['info', 'debug'], {foo: 'bar'});
+			consoleSpy.firstCall.args[0].should.endWith('[info,debug], { foo: \'bar\' }');
+		});
+
+		it('should allow multiple messages', function () {
+			log = new Logger({handler: testHandler, jsonOutput: false});
+			log.log(['info', 'debug'], 'foo', {foo: 'bar'}, 'ping', new Error('shit'));
+			consoleSpy.firstCall.args[0].should.match(/\[info,debug\], foo \{ foo: \'bar\' \} ping Error: shit/);
+		});
+
+		it('should interpolate messages', function () {
+			log = new Logger({handler: testHandler, jsonOutput: false});
+			log.log(['info', 'debug'], '%s,%s', 'foo', 'bar');
+			consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo,bar');
+		});
 	});
 
-	it('should allow multiple messages', function () {
-		log = new Logger({handler: testHandler});
-		log.log(['info', 'debug'], 'foo', {foo: 'bar'}, 'ping');
-		consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo { foo: \'bar\' } ping');
-	});
+	describe('jsonOutput', function () {
+		it('should output in json', function () {
+			log = new Logger({handler: testHandler, jsonOutput: true});
+			log.log('info', 'bar');
+			var json = JSON.parse(consoleSpy.firstCall.args[0]);
+			should.exist(json.time);
+			json.msg.should.equal('bar');
+			json.tags.should.eql(['info']);
+		});
 
-	it('should interpolate messages', function () {
-		log = new Logger({handler: testHandler});
-		log.log(['info', 'debug'], '%s,%s', 'foo', 'bar');
-		consoleSpy.firstCall.args[0].should.endWith('[info,debug], foo,bar');
-	});
+		it('should log object', function () {
+			log = new Logger({handler: testHandler, jsonOutput: true});
+			log.log('info', {foo: 'bar', monkey: 'people'});
+			var json = JSON.parse(consoleSpy.firstCall.args[0]);
+			json.foo.should.equal('bar');
+			json.monkey.should.equal('people');
+		});
 
+		it('should log error stack', function () {
+			log = new Logger({handler: testHandler, jsonOutput: true});
+			log.log('info', new Error('crap'));
+			var json = JSON.parse(consoleSpy.firstCall.args[0]);
+			json.error.should.startWith('Error: crap\n');
+		});
+
+	});
 });


### PR DESCRIPTION
Example output:

Logged string will be assigned to the attribute `msg`.

`{"time":"2015-11-19 16:08:47.440","tags":["log","info"],"msg":"dredition-api v0.11.1 started at: http://fist.local:8000"}``

Logging a single error object will be assigned to the attribute `error`.

`{"time":"2015-11-19 16:08:47.438","tags":["log","error"],"error":"Error: shit... full stack"}`

Logged objects will be merged. e.g `log('info', {foo: 'bar'});`

`{"time":"2015-11-19 16:08:47.438","tags":["info"],"foo":"bar"}`

Response log.

`{"time":"2015-11-19 16:09:16.936","tags":["response"],"requestId":"1447945756936:fist.local:96488:ih6di12x:10000","remoteAddress":"127.0.0.1","host":"http://fist.local:8000","path":"/status","method":"get","query":{},"statusCode":200,"responseTime":16,"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/46.0.2490.80 Safari/537.36"}`
