### PR TITLE
Add contentLength for response logs using json format.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -36,6 +36,7 @@ function defaultMeta(request) {
  * @property {Number} statusCode
  * @property {Number} responseTime
  * @property {String} userAgent
+ * @property {String} [contentLength]
  * @property {String} [referer]
  */
 
@@ -113,6 +114,7 @@ Logger.prototype.handleRequest = function (request, event) {
  */
 Logger.prototype.handleResponse = function (request) {
 	var referer = request.raw.req.headers.referer;
+	var contentLength = request.response.headers['content-length'];
 
 	var requestInfo = {
 		remoteAddress: request.info.remoteAddress,
@@ -127,6 +129,10 @@ Logger.prototype.handleResponse = function (request) {
 
 	if (referer) {
 		requestInfo.referer = referer;
+	}
+
+	if (contentLength) {
+		requestInfo.contentLength = contentLength;
 	}
 
 	this.write({
@@ -203,8 +209,8 @@ Logger.prototype.formatter = function (obj) {
 	}
 
 	var formatted = {
-		time: this.formatTime(obj.timestamp),
-		tags: obj.tags
+		_time: this.formatTime(obj.timestamp),
+		_tags: obj.tags
 	};
 
 	formatted = Hoek.applyToDefaults(formatted, obj.data || {});

--- a/test/lib/logger.test.js
+++ b/test/lib/logger.test.js
@@ -30,7 +30,7 @@ describe('Logger', function () {
 
 		log.log('info', 'foo');
 		var json = JSON.parse(consoleSpy.firstCall.args[0]);
-		json.time.should.equal(moment().format('YYYY-MM-DD HH:mm:ss'));
+		json._time.should.equal(moment().format('YYYY-MM-DD HH:mm:ss'));
 	});
 
 	describe('humanReadable Format', function () {
@@ -78,9 +78,9 @@ describe('Logger', function () {
 			log = new Logger({handler: testHandler, jsonOutput: true});
 			log.log('info', 'bar');
 			var json = JSON.parse(consoleSpy.firstCall.args[0]);
-			should.exist(json.time);
+			should.exist(json._time);
 			json.msg.should.equal('bar');
-			json.tags.should.eql(['info']);
+			json._tags.should.eql(['info']);
 		});
 
 		it('should log object', function () {


### PR DESCRIPTION
Add prefix “_” to default keys tags and time since they are so generic, avoids naming clashing.
