### PR TITLE
Fix #6 Cannot read property 'headers' of null in handleResponse.

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -114,7 +114,7 @@ Logger.prototype.handleRequest = function (request, event) {
  */
 Logger.prototype.handleResponse = function (request) {
 	var referer = request.raw.req.headers.referer;
-	var contentLength = request.response.headers['content-length'];
+	var contentLength = Hoek.reach(request, 'response.headers.content-length');
 
 	var requestInfo = {
 		remoteAddress: request.info.remoteAddress,


### PR DESCRIPTION
This fixes the immediate problem however I want to know  why headers might be null, it may be so that we should have accessed it through a different path.
