### PR TITLE
Handle pretty printing of console.log of unexpected format

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - 10
+  - 12.16
 
 cache:
   directories:

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -202,7 +202,7 @@ class Logger {
 		return printf(
 			'%s, [%s], %s%s',
 			this.formatTime(obj.timestamp),
-			obj.tags,
+			obj.tags.join(','),
 			log,
 			obj.data ? ', ' + stringify(obj.data) : ''
 		);

--- a/lib/pretty.js
+++ b/lib/pretty.js
@@ -28,6 +28,10 @@ rl.on('line', (line) => {
 		return formatResponse(json);
 	}
 
+	if (!(json._tags || json.msg)) {
+		return console.log(line);
+	}
+
 	const time = moment(json._time).format('HH:mm:ss');
 
 	const msg = format(


### PR DESCRIPTION
Not sure if this was caused by a change in node version, or if this never worked, but at least tests are passing in latest Node now.

Main reason for fiddling with was the annoying behavior of pretty that any object that did not include _tags would crash the logger.