### PR TITLE
Improve performance

### DIFF
--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const bench = require('fastbench');
+const hapiLog = require('../')({sonic: {fd: process.stderr.fd, sync: true}});
+
+const max = 10;
+const error = new Error('crap');
+
+const run = bench([
+	function benchString(cb) {
+		for (let i = 0; i < max; i++) {
+			hapiLog.log(['info'], 'hello world');
+		}
+		setImmediate(cb);
+	},
+	function benchError(cb) {
+		for (let i = 0; i < max; i++) {
+			hapiLog.log(['info'], error);
+		}
+		setImmediate(cb);
+	},
+	function benchCombined(cb) {
+		for (let i = 0; i < max; i++) {
+			hapiLog.log(['info'], {hello: 'world'}, error, 'Hello world');
+		}
+		setImmediate(cb);
+	}
+
+], 10000);
+
+run(run);
+

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,19 +1,65 @@
 'use strict';
 
 const Hoek = require('@hapi/hoek');
-const moment = require('moment');
 const printf = require('util').format;
-const stringify = require('json-stringify-safe');
+const stringify = require('fast-safe-stringify');
 const inspect = require('util').inspect;
+const SonicBoom = require('sonic-boom');
 
 const internals = {
 	defaults: {
 		jsonOutput: true,
-		format: 'YYYY-MM-DD HH:mm:ss.SSS',
-		utc: false,
-		requestInfoFilter: (requestInfo) => requestInfo
+		formatTimestamp,
+		requestInfoFilter: (requestInfo) => requestInfo,
+		sonic: {fd: process.stdout.fd, sync: true}
 	}
 };
+
+function formatTimestamp(timestamp) {
+	const d = new Date(parseInt(timestamp, 10));
+
+	let month = d.getMonth() + 1;
+	month = month < 10 ? `0${month}` : month;
+
+	let day = d.getDate();
+	day = day < 10 ? `0${day}` : day;
+
+	let hours = d.getDate();
+	hours = hours < 10 ? `0${hours}` : hours;
+
+	let minutes = d.getMinutes();
+	minutes = minutes < 10 ? `0${minutes}` : minutes;
+
+	let seconds = d.getSeconds();
+	seconds = seconds < 10 ? `0${seconds}` : seconds;
+
+	return `${d.getFullYear()}-${month}-${day} ${hours}:${minutes}:${seconds}.${d.getMilliseconds()}`;
+}
+
+const noop = () => {};
+
+// function copied from https://github.com/pinojs/pino
+function buildSafeSonicBoom(opts) {
+	const stream = new SonicBoom(opts);
+	stream.on('error', filterBrokenPipe);
+	return stream;
+
+	function filterBrokenPipe(err) {
+		if (err.code === 'EPIPE') {
+			// If we get EPIPE, we should stop logging here
+			// however we have no control to the consumer of
+			// SonicBoom, so we just overwrite the write method
+			stream.write = noop;
+			stream.end = noop;
+			stream.flushSync = noop; // eslint-disable-line no-sync
+			stream.destroy = noop;
+			return;
+		}
+
+		stream.removeListener('error', filterBrokenPipe);
+		stream.emit('error', err);
+	}
+}
 
 /**
  * Default meta data to append to logs
@@ -25,6 +71,27 @@ function defaultMeta(request) {
 		return;
 	}
 	return {requestId: request.info.id};
+}
+
+/**
+ * defaultHandler for outputing the logs
+ * @param {Object} [opts] sonic boom options
+ * @return {Object}
+ */
+function defaultHandler(opts) {
+	const sonic = buildSafeSonicBoom(opts);
+	return {
+		log(str) {
+			sonic.write(str + '\n');
+		},
+
+		flush(sync = false) {
+			if (sync) {
+				return sonic.flushSync(); // eslint-disable-line no-sync
+			}
+			return sonic.flush();
+		}
+	};
 }
 
 /**
@@ -57,16 +124,17 @@ class Logger {
 	 *
 	 * @class Logger
 	 * @param {Object} [options]
-	 * @param {String} [options.format] date format string
-	 * @param {Boolean} [options.utc] UTC date
+	 * @param {Function} [options.formatTimestamp] function to format timestamp
 	 * @param {Boolean} [options.jsonOutput] output all data as stringified json
 	 * @param {Object} [options.handler] Handler implementing `log(message)` method, defaults to console logging
+	 * @param {Object} [options.sonic] sonic boom options if using default handler
 	 * @param {Function} [options.meta] Should return meta data as an Object that is appended to logs. Default returns {requestId:request.info.id} This function doesnt always recieve request object.
 	 */
 	constructor(options) {
 		this.opts = Hoek.applyToDefaults(internals.defaults, options || {});
-		this.handler = this.opts.handler || console;
+		this.handler = this.opts.handler || defaultHandler(this.opts.sonic);
 		this.meta = this.opts.meta || defaultMeta;
+		this.formatTime = this.opts.formatTimestamp;
 	}
 
 	/**
@@ -81,20 +149,6 @@ class Logger {
 			data: this.meta(request),
 			log: printf('%s, stack:\n%s', data.error.message, data.error.stack)
 		});
-	}
-
-	/**
-	 * Format timestamp
-	 * @param  {Integer} timestamp
-	 * @return {String}
-	 */
-	formatTime(timestamp) {
-		const m = moment(parseInt(timestamp, 10));
-		if (!this.opts.utc) {
-			m.local();
-		}
-
-		return m.format(this.opts.format);
 	}
 
 	/**
@@ -218,19 +272,18 @@ class Logger {
 			return this.humanReadableFormatter(obj);
 		}
 
-		let formatted = {
+		const formatted = {
 			_time: this.formatTime(obj.timestamp),
 			_tags: obj.tags
 		};
 
-		formatted = Hoek.applyToDefaults(formatted, obj.data || {});
-		formatted = Hoek.applyToDefaults(formatted, obj.requestInfo || {});
+		Object.assign(formatted, obj.data || {}, obj.requestInfo || {});
 
 		if (obj.log && !Array.isArray(obj.log) && typeof obj.log === 'object') {
 			if (obj.log instanceof Error) {
 				formatted.error = obj.log.stack;
 			} else {
-				formatted = Hoek.applyToDefaults(formatted, obj.log);
+				Object.assign(formatted, obj.log);
 			}
 		} else {
 			formatted.msg = obj.log;

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "watch": "mocha --watch 'test/**/*.js' --timeout 500",
     "release": "npm test && release-it -n -i patch",
     "release:minor": "npm test && release-it -n -i minor",
-    "release:major": "npm test && release-it -n -i major"
+    "release:major": "npm test && release-it -n -i major",
+    "bench": "node benchmarks/index.js 2>/dev/null"
   },
   "engines": {
     "node": ">=10.0.0"
@@ -26,13 +27,15 @@
   "dependencies": {
     "@hapi/hoek": "^8.0.2",
     "chalk": "^2.4.2",
-    "json-stringify-safe": "^5.0.1",
-    "moment": "^2.24.0"
+    "fast-safe-stringify": "^2.0.7",
+    "sonic-boom": "^1.0.1"
   },
   "devDependencies": {
+    "moment": "^2.24.0",
     "@aptoma/eslint-config": "^7.0.1",
     "@hapi/hapi": "^18.3.1",
     "eslint": "^6.0.1",
+    "fastbench": "^1.0.1",
     "mocha": "^6.1.4",
     "nyc": "^14.1.1",
     "release-it": "^2.0.3",

--- a/test/lib/logger.test.js
+++ b/test/lib/logger.test.js
@@ -20,12 +20,13 @@ describe('Logger', () => {
 		testHandler.log.restore();
 	});
 
-	it('should support custom timeformat', () => {
+	it('should support custom time formatter', () => {
 		log = new Logger({
 			jsonOutput: true,
 			handler: testHandler,
-			format: 'YYYY-MM-DD HH:mm:ss',
-			utc: true
+			formatTimestamp(ts) {
+				return moment(ts).format('YYYY-MM-DD HH:mm:ss');
+			}
 		});
 
 		log.log('info', 'foo');


### PR DESCRIPTION
Was reading about performance and logging and thought it would be interesting to see how hapi-log stands compared to others. Simply put it was horrible.

This introduces some breaking changes. Date formatting is just a sad thing, this has been replaced with a simple one that conforms to our most common style with a new option `formatTimestamp`  to pass in your own function for formatting a timestamp. All old formatting options for times has been removed.

### Benchmarks

The benchmarks are writing 10 lines 10000 times.

**Before**

```
benchString*10000: 2373.986ms
benchError*10000: 2407.298ms
benchCombined*10000: 2736.522ms
```

**After sync writing**

```
benchString*10000: 628.928ms
benchError*10000: 713.008ms
benchCombined*10000: 959.710ms
```

**After async writing**
```
benchString*10000: 277.393ms
benchError*10000: 381.088ms
benchCombined*10000: 559.997ms
```

Benchmarks for every incremental change with `noop` writing

**Baseline**

```
benchString*10000: 1718.167ms
benchError*10000: 1806.478ms
benchCombined*10000: 2112.879ms
```

**Replace json-stringify-safe  with fast-safe-stringify**

```
benchString*10000: 1497.956ms
benchError*10000: 1491.109ms
benchCombined*10000: 1814.321ms
```

**Replace Hoek.applyToDefaults with Object.assign**

```
benchString*10000: 784.983ms
benchError*10000: 785.215ms
benchCombined*10000: 1020.040ms
```

**Remove moment timestamp formatting**

```
benchString*10000: 380.328ms
benchError*10000: 498.167ms
benchCombined*10000: 664.189ms
```

**Console.log vs Sonic boom for writing**

**Async**

```
benchSonic*10000: 106.746ms
benchConsole*10000: 461.731ms
```

**Sync**

```
benchSonic*10000: 329.432ms
benchConsole*10000: 450.533ms
```