### PR TITLE
Remove sonic-boom, use process.stdout.write as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ Creating releases
 	$ npm run release:minor
 	$ npm run release:major
 
+Running benchmarks
+
+	$ npm run bench
+
 ## Developer friendly output
 
 This package includes a script called `pretty-hapi-log` which can be used to parse the output and make it colorful and pretty.

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,7 +1,11 @@
 'use strict';
 
 const bench = require('fastbench');
-const hapiLog = require('../')({sonic: {fd: process.stderr.fd, sync: true}});
+const hapiLog = require('../')({handler: {
+	log(msg) {
+		process.stderr.write(msg + '\n');
+	}
+}});
 
 const max = 10;
 const error = new Error('crap');
@@ -29,4 +33,3 @@ const run = bench([
 ], 10000);
 
 run(run);
-

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -4,14 +4,12 @@ const Hoek = require('@hapi/hoek');
 const printf = require('util').format;
 const stringify = require('fast-safe-stringify');
 const inspect = require('util').inspect;
-const SonicBoom = require('sonic-boom');
 
 const internals = {
 	defaults: {
 		jsonOutput: true,
 		formatTimestamp,
-		requestInfoFilter: (requestInfo) => requestInfo,
-		sonic: {fd: process.stdout.fd, sync: true}
+		requestInfoFilter: (requestInfo) => requestInfo
 	}
 };
 
@@ -36,31 +34,6 @@ function formatTimestamp(timestamp) {
 	return `${d.getFullYear()}-${month}-${day} ${hours}:${minutes}:${seconds}.${d.getMilliseconds()}`;
 }
 
-const noop = () => {};
-
-// function copied from https://github.com/pinojs/pino
-function buildSafeSonicBoom(opts) {
-	const stream = new SonicBoom(opts);
-	stream.on('error', filterBrokenPipe);
-	return stream;
-
-	function filterBrokenPipe(err) {
-		if (err.code === 'EPIPE') {
-			// If we get EPIPE, we should stop logging here
-			// however we have no control to the consumer of
-			// SonicBoom, so we just overwrite the write method
-			stream.write = noop;
-			stream.end = noop;
-			stream.flushSync = noop; // eslint-disable-line no-sync
-			stream.destroy = noop;
-			return;
-		}
-
-		stream.removeListener('error', filterBrokenPipe);
-		stream.emit('error', err);
-	}
-}
-
 /**
  * Default meta data to append to logs
  * @param  {Object} request
@@ -75,21 +48,12 @@ function defaultMeta(request) {
 
 /**
  * defaultHandler for outputing the logs
- * @param {Object} [opts] sonic boom options
  * @return {Object}
  */
-function defaultHandler(opts) {
-	const sonic = buildSafeSonicBoom(opts);
+function defaultHandler() {
 	return {
 		log(str) {
-			sonic.write(str + '\n');
-		},
-
-		flush(sync = false) {
-			if (sync) {
-				return sonic.flushSync(); // eslint-disable-line no-sync
-			}
-			return sonic.flush();
+			process.stdout.write(str + '\n');
 		}
 	};
 }
@@ -127,12 +91,11 @@ class Logger {
 	 * @param {Function} [options.formatTimestamp] function to format timestamp
 	 * @param {Boolean} [options.jsonOutput] output all data as stringified json
 	 * @param {Object} [options.handler] Handler implementing `log(message)` method, defaults to console logging
-	 * @param {Object} [options.sonic] sonic boom options if using default handler
 	 * @param {Function} [options.meta] Should return meta data as an Object that is appended to logs. Default returns {requestId:request.info.id} This function doesnt always recieve request object.
 	 */
 	constructor(options) {
 		this.opts = Hoek.applyToDefaults(internals.defaults, options || {});
-		this.handler = this.opts.handler || defaultHandler(this.opts.sonic);
+		this.handler = this.opts.handler || defaultHandler();
 		this.meta = this.opts.meta || defaultMeta;
 		this.formatTime = this.opts.formatTimestamp;
 	}

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
   "dependencies": {
     "@hapi/hoek": "^8.0.2",
     "chalk": "^2.4.2",
-    "fast-safe-stringify": "^2.0.7",
-    "sonic-boom": "^1.0.1"
+    "fast-safe-stringify": "^2.0.7"
   },
   "devDependencies": {
     "moment": "^2.24.0",


### PR DESCRIPTION
Some tools such as pm2 and lambda monkey patches process.stdout.write which makes sonic-boom not optimal as a default.