### PR TITLE
Colorize log lines based on tag values

### DIFF
--- a/lib/pretty.js
+++ b/lib/pretty.js
@@ -37,7 +37,7 @@ rl.on('line', (line) => {
 	const msg = format(
 		`%s ${chalk.gray('[')}%s${chalk.gray(']')} ${chalk.gray('-')} %s %s`,
 		chalk.gray(time),
-		json._tags.map((t, idx) => cycleColor(t, idx)).join(', '),
+		colorizeTags(json._tags),
 		json.msg || '',
 		props(json, ['msg', '_time', '_tags'])
 	);
@@ -61,8 +61,14 @@ function stringify(data) {
 	return JSON.stringify(data);
 }
 
-function cycleColor(str, idx) {
-	return idx % 2 === 0 ? chalk.blue(str) : chalk.cyan(str);
+function colorizeTags(tags) {
+	let colors = [chalk.blue, chalk.cyan];
+	if (tags.find((tag) => tag === 'error')) {
+		colors = [chalk.red.bold, chalk.red];
+	} else if (tags.find((tag) => tag.startsWith('warn'))) {
+		colors = [chalk.yellow.bold, chalk.yellow];
+	}
+	return tags.map((t, idx) => idx % 2 === 0 ? colors[0](t) : colors[1](t)).join(', ');
 }
 
 function formatResponse(json) {

--- a/package.json
+++ b/package.json
@@ -27,10 +27,10 @@
   "dependencies": {
     "@hapi/hoek": "^8.0.2",
     "chalk": "^2.4.2",
-    "fast-safe-stringify": "^2.0.7"
+    "fast-safe-stringify": "^2.0.7",
+    "moment": "^2.27.0"
   },
   "devDependencies": {
-    "moment": "^2.24.0",
     "@aptoma/eslint-config": "^7.0.1",
     "@hapi/hapi": "^18.3.1",
     "eslint": "^6.0.1",


### PR DESCRIPTION
Currently, we only colorize responses >300, but not errors/warnings logged manually. Add red/yellow color for easier visual grepping when working locally.