### PR TITLE
Support extracting log level to a separate field

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -240,24 +240,23 @@ class Logger {
 	}
 
 	/**
-	 * Attempts to find a standard log level among the tag values. If found, the log level
-	 * is removed from the tag array and returned.
+	 * Attempts to verify that the first tag is a log level. If so, the log
+	 * level is removed from the tag array and returned.
 	 *
 	 * @param {string[]} tags
 	 * @return {string|undefined}
 	 */
 	extractLogLevel(tags) {
-		if (!this.opts.extractLogLevel) {
+		if (!this.opts.extractLogLevel || !tags || !tags.length) {
 			return undefined;
 		}
 		// Support the whole RFC 5424 set, it's the closest we have to a standard for these things.
 		// See https://en.wikipedia.org/wiki/Syslog#Severity_level.
 		const regex = /^info$|^warn(ing)?$|^err(or)?$|^notice$|^debug$|^emerg$|^panic$|^crit$|^alert$|^fatal$|^trace$/i;
-		const logLevelIndex = tags.findIndex((tag) => regex.test(tag));
-		if (logLevelIndex === -1) {
-			return undefined;
+		if (regex.test(tags[0])) {
+			return tags.splice(0, 1)[0].toLowerCase();
 		}
-		return tags.splice(logLevelIndex, 1)[0].toLowerCase();
+		return undefined;
 	}
 
 	/**

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,6 +9,7 @@ const format = require('./format');
 const internals = {
 	defaults: {
 		jsonOutput: true,
+		extractLogLevel: false,
 		formatTimestamp: format.timestamp,
 		requestInfoFilter: (requestInfo) => requestInfo
 	}
@@ -71,6 +72,7 @@ class Logger {
 	 * @param {Object} [options]
 	 * @param {Function} [options.formatTimestamp] function to format timestamp
 	 * @param {Boolean} [options.jsonOutput] output all data as stringified json
+	 * @param {Boolean} [options.extractLogLevel] extract log level from tags and add as a separate value
 	 * @param {Object} [options.handler] Handler implementing `log(message)` method, defaults to console logging
 	 * @param {Function} [options.meta] Should return meta data as an Object that is appended to logs. Default returns {requestId:request.info.id} This function doesnt always recieve request object.
 	 */
@@ -218,6 +220,7 @@ class Logger {
 
 		const formatted = {
 			_time: this.formatTime(obj.timestamp),
+			_level: this.extractLogLevel(obj.tags),
 			_tags: obj.tags
 		};
 
@@ -234,6 +237,27 @@ class Logger {
 		}
 
 		return stringify(formatted);
+	}
+
+	/**
+	 * Attempts to find a standard log level among the tag values. If found, the log level
+	 * is removed from the tag array and returned.
+	 *
+	 * @param {string[]} tags
+	 * @return {string|undefined}
+	 */
+	extractLogLevel(tags) {
+		if (!this.opts.extractLogLevel) {
+			return undefined;
+		}
+		// Support the whole RFC 5424 set, it's the closest we have to a standard for these things.
+		// See https://en.wikipedia.org/wiki/Syslog#Severity_level.
+		const regex = /^info$|^warn(ing)?$|^err(or)?$|^notice$|^debug$|^emerg$|^panic$|^crit$|^alert$|^fatal$|^trace$/i;
+		const logLevelIndex = tags.findIndex((tag) => regex.test(tag));
+		if (logLevelIndex === -1) {
+			return undefined;
+		}
+		return tags.splice(logLevelIndex, 1)[0].toLowerCase();
 	}
 
 	/**

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -368,6 +368,90 @@ describe('Log service', () => {
 		should.ok(index('foo') === log1);
 	});
 
+	it('should extract log level if extractLogLevel is true', () => {
+		let line = {};
+		const logger = index('extract:1', {
+			extractLogLevel: true,
+			handler: {
+				log(str) {
+					line = JSON.parse(str);
+				}
+			}
+		});
+		const levels = ['info', 'warn', 'warning', 'err', 'error', 'fatal', 'debug'];
+		levels.forEach((level) => {
+			logger.log([level]);
+			should.equal(line._level, level);
+			should.equal(line._tags.length, 0);
+
+			logger.log(['other_tag', level]);
+			should.equal(line._level, level);
+			should.equal(line._tags.length, 1);
+
+			logger.log(['other_tag', 'yet_another_tag', level]);
+			should.equal(line._level, level);
+			should.equal(line._tags.length, 2);
+		});
+	});
+
+	it('should leave tags unchanged if extractLogLevel is false', () => {
+		let line = {};
+		const logger = index('extract:2', {
+			extractLogLevel: false,
+			handler: {
+				log(str) {
+					line = JSON.parse(str);
+				}
+			}
+		});
+		const levels = ['info', 'warn', 'warning', 'err', 'error', 'fatal', 'debug'];
+		levels.forEach((level) => {
+			let tags = [level];
+			logger.log(tags);
+			should.equal(line._level, undefined);
+			should.deepEqual(line._tags, tags);
+
+			tags = ['other_tag', level];
+			logger.log(tags);
+			should.equal(line._level, undefined);
+			should.deepEqual(line._tags, tags);
+
+			tags = ['other_tag', 'yet_another_tag', level];
+			logger.log(tags);
+			should.equal(line._level, undefined);
+			should.deepEqual(line._tags, tags);
+		});
+	});
+
+	it('should leave tags unchanged if there is no log level in the tags', () => {
+		let line = {};
+		const logger = index('extract:3', {
+			extractLogLevel: false,
+			handler: {
+				log(str) {
+					line = JSON.parse(str);
+				}
+			}
+		});
+		const levels = ['foo', 'bar', 'information', 'terror'];
+		levels.forEach((level) => {
+			let tags = [level];
+			logger.log(tags);
+			should.equal(line._level, undefined);
+			should.deepEqual(line._tags, tags);
+
+			tags = ['other_tag', level];
+			logger.log(tags);
+			should.equal(line._level, undefined);
+			should.deepEqual(line._tags, tags);
+
+			tags = ['other_tag', 'yet_another_tag', level];
+			logger.log(tags);
+			should.equal(line._level, undefined);
+			should.deepEqual(line._tags, tags);
+		});
+	});
+
 	function route(path, handler, method) {
 		server.route({
 			method: method || 'GET',

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -368,7 +368,7 @@ describe('Log service', () => {
 		should.ok(index('foo') === log1);
 	});
 
-	it('should extract log level if extractLogLevel is true', () => {
+	it('should extract log level from the first tag if extractLogLevel is true', () => {
 		let line = {};
 		const logger = index('extract:1', {
 			extractLogLevel: true,
@@ -385,11 +385,7 @@ describe('Log service', () => {
 			should.equal(line._tags.length, 0);
 
 			logger.log(['other_tag', level]);
-			should.equal(line._level, level);
-			should.equal(line._tags.length, 1);
-
-			logger.log(['other_tag', 'yet_another_tag', level]);
-			should.equal(line._level, level);
+			should.equal(line._level, undefined);
 			should.equal(line._tags.length, 2);
 		});
 	});


### PR DESCRIPTION
Support extracting the log level to a separate field, which we can then have loki parse to a label and index. Then we can avoid the whole `first_tag="error" or second_tag="error"`. We're currently having to parse and search ALL log lines in order to find errors, which is just stupid. The format Hapi have chosen for tags doesn't help. A string array is a weird choice, it's literally the least searchable data structure they could have chosen. With this change, and an adjustment to the log export config, we can instead do `{app="myapp", level="error"}` and it'll just pull directly from the index.

If enabled, the logger will look for a standard log level in the tags, remove it, and add it as a separate key. If we can't find a log level we leave the tags array unchanged.