### PR TITLE
Remove prepended tag "log" on server.log

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -178,7 +178,7 @@ class Logger {
 	handleLog(event) {
 		this.write({
 			timestamp: event.timestamp,
-			tags: ['log'].concat(event.tags),
+			tags: event.tags,
 			log: event.data || event.error
 		});
 	}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -350,7 +350,7 @@ describe('Log service', () => {
 
 	it('should handle log event', (done) => {
 		testHandler.listener = (data) => {
-			data.should.endWith('[log,foo], { foo: \'bar\' }');
+			data.should.endWith('[foo], { foo: \'bar\' }');
 			done();
 		};
 


### PR DESCRIPTION
Not sure why it was there in the first place. 
As previous mentioned we would want to be able to set severity as the first tag.
However we were unable todo so with this prepended log tag.