### PR TITLE
Remove prepended tag log on req.log

### DIFF
--- a/lib/logger.js
+++ b/lib/logger.js
@@ -103,7 +103,7 @@ class Logger {
 	handleRequest(request, event) {
 		this.write({
 			timestamp: event.timestamp,
-			tags: ['log'].concat(event.tags),
+			tags: event.tags,
 			data: this.meta(request),
 			log: event.data || event.error
 		});


### PR DESCRIPTION
Repeat of https://github.com/aptoma/hapi-log/pull/26.

We're still appending the tag `'log'` to all lines logged with `req.log()`, which doesn't work with the log level extraction.